### PR TITLE
Feature/wsl distribution class

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,45 @@
 Powershell cmdlet to quickly create a minimal WSL distribution. Currently, it
 can create an Archlinux, Alpine (3.17) or Ubuntu (22.10) based distribution. It
 is available in PowerShell Gallery as
-[`Wsl-Manager`](https://www.powershellgallery.com/packages/Wsl-Manager/1.1.1).
+[`Wsl-Manager`](https://www.powershellgallery.com/packages/Wsl-Manager/1.2.0).
 
 This project is generalization of its sister project
 [PowerShell-Wsl-Alpine](https://github.com/antoinemartin/PowerShell-Wsl-Alpine).
 
 ## Rationale
 
-As a developer working mainly on Linux, I have the tendency to put everything in
-the same WSL distribution, ending up with a distribution containing Go, Python,
-Terraform...
+Windows is a great development platform for Linux based backend services through
+[Visual Studio Code and WSL](https://code.visualstudio.com/docs/remote/wsl).
 
-This module is here to reduce the time of spawning a new distrbution for
-development in order to have concerns more splitted. It is also a reminder of
-the congfiguration steps to have a working distribution.
+However, using a single Linux distrbution is unpratictal as it tends to get
+bloated and becomes difficult to recreate if configured manually.
+
+It is much better to use a distribution per development envinronment given that
+the performance overhead is low.
+
+Creating a WSL distribution from a Linux distro Root filesystem
+([Ubuntu](https://cloud-images.ubuntu.com/wsl/),
+[Arch](https://archive.archlinux.org/iso/2022.12.01/),
+[Alpine](https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/)) is
+relatively easy but can rapidely become a tedious task.
+
+The `Wsl-Manager` module streamlines that.
 
 ## What it does
 
-This module provides a cmdlet called `Install-Wsl` that will install a
-lightweight Windows Subsystem for Linux (WSL) distribution.
+This module allows to easily create and manage lightweight WSL distributions. It
+provides support for the following distros:
 
-This command performs the following operations:
+- [Alpine (3.17)](https://www.alpinelinux.org/) is the lightest and allows
+  developing in the same environment as most docker containers.
+- [Arch Linux](https://archlinux.org/) is the most up to date and versatile.
+- [Ubunty (22.10)](https://ubuntu.com/) is the most used. In particular, it
+  allows simulating the Github Actions runner.
 
-- Create a Distribution directory,
-- Download the Root Filesystem,
-- Create the WSL distribution,
-- Configure the WSL distribution.
+It provides a cmdlet called `Install-Wsl` that will install a lightweight
+Windows Subsystem for Linux (WSL) distribution.
 
-The distribution is configured as follows:
+The installed distribution is configured as follows:
 
 - A user named after the type of distribution (`arch`, `alpine` or `ubuntu`) is
   set as the default user. The user as `sudo` (`doas` on Alpine) privileges.
@@ -41,8 +52,19 @@ The distribution is configured as follows:
   is installed.
 - The
   [wsl2-ssh-pageant](https://github.com/antoinemartin/wsl2-ssh-pageant-oh-my-zsh-plugin)
-  plugin is installed in order to use the GPG keys private keys available at the
-  Windows level (I personally use a Yubikey).
+  plugin is installed in order to use the GPG private keys available at the
+  Windows level both for SSH and GPG (I personally use a Yubikey).
+
+You can install an already configured distribution (`-Configured` flag) or start
+from the official root filesystem and perform the configuration locally on the
+newly created distrbution.
+
+The root filesystems from which the WSL distributions are created are cached in
+the `%LOCALAPPDATA%\Wsl\RootFS` directory when downloaded and reused for further
+creations.
+
+By default, each created WSL distribution home folder (where the `ext4.vhdx`
+virtual filesystem file is located) is located in `%LOCALAPPDATA%\Wsl`
 
 ## Pre-requisites
 
@@ -97,14 +119,14 @@ It will remove the distrbution and wipe the directory completely.
 ## Using already configured Filesystems
 
 Configuration implies installing some packages. To avoid the time taken to
-download and install such packages, Already configured root images are made
-available on
+download and install such packages, Already configured root filesystems files
+are made available on
 [github](https://github.com/antoinemartin/PowerShell-Wsl-Manager/releases/tag/latest).
 
 You can install an already configured distrbution by adding the `-Configured`
 switch:
 
-````powershell
+```powershell
 ❯ install-wsl test2 -Distribution Alpine -Configured
 ####> Creating directory [C:\Users\AntoineMartin\AppData\Local\Wsl\test2]...
 ####> Downloading  https://github.com/antoinemartin/PowerShell-Wsl-Manager/releases/download/latest/miniwsl.alpine.rootfs.tar.gz => C:\Users\AntoineMartin\AppData\Local\Wsl\RootFS\miniwsl.alpine.rootfs.tar.gz...
@@ -128,16 +150,13 @@ First install the distribution:
 ####> Running initialization script [configure_arch.sh] on distribution [docker]...
 ####> Done. Command to enter distribution: wsl -d docker
 ❯
-````
+```
 
 Connect to it as root and install docker:
 
 ```bash
-# Connect to the distribution
-❯ wsl -d docker -u root
-[powerlevel10k] fetching gitstatusd .. [ok]
-# Add docker
-❯ pacman -Sy --noconfirm --needed docker
+# Add docker to the distribution
+❯ wsl -d docker -u root pacman -Sy --noconfirm --needed docker
 :: Synchronizing package databases...
  core is up to date
  extra is up to date
@@ -165,7 +184,7 @@ Add the `arch` user to the docker group:
 
 ```bash
 # Adding base user as docker
-❯ usermod -aG docker arch
+❯ wsl -d docker -u root usermod -aG docker arch
 ```
 
 Now, with this distribution, you can add the following alias to
@@ -176,16 +195,12 @@ function RunDockerInWsl {
   # Take $Env:DOCKER_WSL or 'docker' if undefined
   $DockerWSL = if ($null -eq $Env:DOCKER_WSL) { "docker" } else { $Env:DOCKER_WSL }
   # Try to find an existing distribution with the name
-  $existing = Get-ChildItem HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss |  Where-Object { $_.GetValue('DistributionName') -eq $DockerWSL }
-  if ($null -eq $existing) {
-    # Fail if the distribution doesn't exist
-    throw "The WSL distribution [$DockerWSL] does not exist !"
-  } else {
-    # Ensure docker is started
-    wsl -d $DockerWSL /bin/sh -c "test -f /var/run/docker.pid || sudo -b sh -c 'dockerd -p /var/run/docker.pid -H unix:// >/var/log/docker.log 2>&1'"
-    # Perform the requested command
-    wsl -d $DockerWSL /usr/bin/docker $args
-  }
+  $existing = Get-Wsl $DockerWSL
+
+  # Ensure docker is started
+  wsl.exe -d $existing.Name /bin/sh "-c" "test -f /var/run/docker.pid || sudo -b sh -c 'dockerd -p /var/run/docker.pid -H unix:// >/var/log/docker.log 2>&1'"
+  # Perform the requested command
+  wsl.exe -d $existing.Name /usr/bin/docker $Args
 }
 
 Set-Alias -Name docker -Value RunDockerInWsl

--- a/README.md
+++ b/README.md
@@ -257,9 +257,14 @@ To modify the module, clone it in your local modules directory:
 ❯ git clone https://github.com/antoinemartin/PowerShell-Wsl-Manager Wsl-Manager
 ```
 
+## Aknowledgements
+
+- [SvenGroot/WslManagementPS](https://github.com/SvenGroot/WslManagementPS) for
+  the distribution class and the pipeline based commands.
+
 ## TODO
 
 - [ ] Move the docker example in the Wiki.
-- [ ] Add a command to retrieve full information on a distribution.
+- [x] Add a command to retrieve full information on a distribution.
 - [ ] Add commands to manage the root fs cache.
 - [ ] Add a command to intialize Wsl.

--- a/Wsl-Manager.psd1
+++ b/Wsl-Manager.psd1
@@ -69,7 +69,7 @@
     # NestedModules = @()
 
     # Fonctions à exporter à partir de ce module. Pour de meilleures performances, n’utilisez pas de caractères génériques et ne supprimez pas l’entrée. Utilisez un tableau vide si vous n’avez aucune fonction à exporter.
-    FunctionsToExport = @("Install-Wsl", "Uninstall-Wsl", "Export-Wsl", "Get-WslRootFS", "Get-Wsl")
+    FunctionsToExport = @("Install-Wsl", "Uninstall-Wsl", "Export-Wsl", "Get-WslRootFS", "Get-Wsl", "Invoke-Wsl")
 
     # Applets de commande à exporter à partir de ce module. Pour de meilleures performances, n’utilisez pas de caractères génériques et ne supprimez pas l’entrée. Utilisez un tableau vide si vous n’avez aucune applet de commande à exporter.
     CmdletsToExport   = @()

--- a/Wsl-Manager.psd1
+++ b/Wsl-Manager.psd1
@@ -69,7 +69,7 @@
     # NestedModules = @()
 
     # Fonctions à exporter à partir de ce module. Pour de meilleures performances, n’utilisez pas de caractères génériques et ne supprimez pas l’entrée. Utilisez un tableau vide si vous n’avez aucune fonction à exporter.
-    FunctionsToExport = @("Install-Wsl", "Uninstall-Wsl", "Export-Wsl", "Get-WslRootFS")
+    FunctionsToExport = @("Install-Wsl", "Uninstall-Wsl", "Export-Wsl", "Get-WslRootFS", "Get-Wsl")
 
     # Applets de commande à exporter à partir de ce module. Pour de meilleures performances, n’utilisez pas de caractères génériques et ne supprimez pas l’entrée. Utilisez un tableau vide si vous n’avez aucune applet de commande à exporter.
     CmdletsToExport   = @()

--- a/Wsl-Manager.psm1
+++ b/Wsl-Manager.psm1
@@ -12,15 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+using namespace System.IO;
 
 class UnknownDistributionException : System.SystemException {
-    UnknownDistributionException([string] $Name) : base("Unknown distribution $Name") {
+    UnknownDistributionException([string[]] $Name) : base("Unknown distribution(s): $($Name -join ', ')") {
     }
 }
 
 class DistributionAlreadyExistsException: System.SystemException {
     DistributionAlreadyExistsException([string] $Name) : base("Distribution $Name already exists") {
     }
+}
+
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', $null, Scope = 'Function')]
+    $IsWindows = $true
 }
 
 if ($IsWindows) {
@@ -35,6 +41,237 @@ else {
     # If running inside WSL, rely on wsl.exe being in the path.
     $wslPath = "wsl.exe"
 }
+
+
+# Helper that will launch wsl.exe, correctly parsing its output encoding, and throwing an error
+# if it fails.
+function Invoke-Wsl {
+    $hasError = $false
+    try {
+        $oldOutputEncoding = [System.Console]::OutputEncoding
+        [System.Console]::OutputEncoding = [System.Text.Encoding]::Unicode
+        $output = &$wslPath $args
+        if ($LASTEXITCODE -ne 0) {
+            throw "Wsl.exe failed: $output"
+            $hasError = $true
+        }
+
+    }
+    finally {
+        [System.Console]::OutputEncoding = $oldOutputEncoding
+    }
+
+    # $hasError is used so there's no output in case error action is silently continue.
+    if (-not $hasError) {
+        return $output
+    }
+}
+
+enum WslDistributionState {
+    Stopped
+    Running
+    Installing
+    Uninstalling
+    Converting
+}
+
+# Represents a WSL distribution.
+class WslDistribution {
+    WslDistribution() {
+        $this | Add-Member -Name FileSystemPath -Type ScriptProperty -Value {
+            return "\\wsl$\$($this.Name)"
+        }
+
+        $this | Add-Member -Name BlockFile -Type ScriptProperty -Value {
+            return $this.BasePath | Get-ChildItem -Filter ext4.vhdx
+        }
+
+        $this | Add-Member -Name Size -Type ScriptProperty -Value {
+            return $this.BlockFile.Length / 1MB
+        }
+
+        $defaultDisplaySet = "Name", "State", "Version", "Default"
+
+        #Create the default property display set
+        $defaultDisplayPropertySet = New-Object System.Management.Automation.PSPropertySet("DefaultDisplayPropertySet", [string[]]$defaultDisplaySet)
+        $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]@($defaultDisplayPropertySet)
+        $this | Add-Member MemberSet PSStandardMembers $PSStandardMembers
+    }
+
+    [string] ToString() {
+        return $this.Name
+    }
+
+    [string] Unregister() {
+        return Invoke-Wsl --unregister $this.Name
+    }
+
+    [string] Stop() {
+        return Invoke-Wsl --terminate $this.Name
+    }
+
+    [string]$Name
+    [WslDistributionState]$State
+    [int]$Version
+    [bool]$Default
+    [Guid]$Guid
+    [FileSystemInfo]$BasePath
+}
+
+
+
+# Helper to parse the output of wsl.exe --list
+function Get-WslHelper() {
+    Invoke-Wsl --list --verbose | Select-Object -Skip 1 | ForEach-Object { 
+        $fields = $_.Split(@(" "), [System.StringSplitOptions]::RemoveEmptyEntries) 
+        $defaultDistro = $false
+        if ($fields.Count -eq 4) {
+            $defaultDistro = $true
+            $fields = $fields | Select-Object -Skip 1
+        }
+
+        [WslDistribution]@{
+            "Name"    = $fields[0]
+            "State"   = $fields[1]
+            "Version" = [int]$fields[2]
+            "Default" = $defaultDistro
+        }
+    }
+}
+
+
+# Helper to get additional distribution properties from the registry.
+function Get-WslProperties([WslDistribution]$Distribution) {
+    $key = Get-ChildItem "hkcu:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss" | Get-ItemProperty | Where-Object { $_.DistributionName -eq $Distribution.Name }
+    if ($key) {
+        $Distribution.Guid = $key.PSChildName
+        $path = $key.BasePath
+        if ($path.StartsWith("\\?\")) {
+            $path = $path.Substring(4)
+        }
+
+        $Distribution.BasePath = Get-Item -Path $path
+    }
+}
+
+function Get-Wsl {
+    <#
+    .SYNOPSIS
+        Gets the WSL distributions installed on the computer.
+    .DESCRIPTION
+        The Get-Wsl cmdlet gets objects that represent the WSL distributions on the computer.
+        This cmdlet wraps the functionality of "wsl.exe --list --verbose".
+    .PARAMETER Name
+        Specifies the distribution names of distributions to be retrieved. Wildcards are permitted. By
+        default, this cmdlet gets all of the distributions on the computer.
+    .PARAMETER Default
+        Indicates that this cmdlet gets only the default distribution. If this is combined with other
+        parameters such as Name, nothing will be returned unless the default distribution matches all the
+        conditions. By default, this cmdlet gets all of the distributions on the computer.
+    .PARAMETER State
+        Indicates that this cmdlet gets only distributions in the specified state (e.g. Running). By
+        default, this cmdlet gets all of the distributions on the computer.
+    .PARAMETER Version
+        Indicates that this cmdlet gets only distributions that are the specified version. By default,
+        this cmdlet gets all of the distributions on the computer.
+    .INPUTS
+        System.String
+        You can pipe a distribution name to this cmdlet.
+    .OUTPUTS
+        WslDistribution
+        The cmdlet returns objects that represent the distributions on the computer.
+    .EXAMPLE
+        Get-Wsl
+        Name           State Version Default
+        ----           ----- ------- -------
+        Ubuntu       Stopped       2    True
+        Ubuntu-18.04 Running       1   False
+        Alpine       Running       2   False
+        Debian       Stopped       1   False
+        Get all WSL distributions.
+    .EXAMPLE
+        Get-Wsl -Default
+        Name           State Version Default
+        ----           ----- ------- -------
+        Ubuntu       Stopped       2    True
+        Get the default distribution.
+    .EXAMPLE
+        Get-Wsl -Version 2 -State Running
+        Name           State Version Default
+        ----           ----- ------- -------
+        Alpine       Running       2   False
+        Get running WSL2 distributions.
+    .EXAMPLE
+        Get-Wsl Ubuntu* | Stop-WslDistribution
+        Terminate all distributions that start with Ubuntu
+    .EXAMPLE
+        Get-Content distributions.txt | Get-Wsl
+        Name           State Version Default
+        ----           ----- ------- -------
+        Ubuntu       Stopped       2    True
+        Debian       Stopped       1   False
+        Use the pipeline as input.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [ValidateNotNullOrEmpty()]
+        [SupportsWildcards()]
+        [string[]]$Name,
+        [Parameter(Mandatory = $false)]
+        [Switch]$Default,
+        [Parameter(Mandatory = $false)]
+        [WslDistributionState]$State,
+        [Parameter(Mandatory = $false)]
+        [int]$Version
+    )
+
+    process {
+        $distributions = Get-WslHelper
+        if ($Default) {
+            $distributions = $distributions | Where-Object {
+                $_.Default
+            }
+        }
+
+        if ($PSBoundParameters.ContainsKey("State")) {
+            $distributions = $distributions | Where-Object {
+                $_.State -eq $State
+            }
+        }
+
+        if ($PSBoundParameters.ContainsKey("Version")) {
+            $distributions = $distributions | Where-Object {
+                $_.Version -eq $Version
+            }
+        }
+
+        if ($Name.Length -gt 0) {
+            $distributions = $distributions | Where-Object {
+                foreach ($pattern in $Name) {
+                    if ($_.Name -ilike $pattern) {
+                        return $true
+                    }
+                }
+                
+                return $false
+            }
+            if ($null -eq $distributions) {
+                throw [UnknownDistributionException] $Name
+            }
+        }
+
+        # The additional registry properties aren't available if running inside WSL.
+        if ($IsWindows) {
+            $distributions | ForEach-Object {
+                Get-WslProperties $_
+            }
+        }
+
+        return $distributions
+    }
+}
+
 
 
 $module_directory = ([System.IO.FileInfo]$MyInvocation.MyCommand.Path).DirectoryName
@@ -316,22 +553,39 @@ function Uninstall-Wsl {
         distribution base root filesystem and the directory of the distribution.
 
     .PARAMETER Name
-        The name of the distribution. If ommitted, will take WslArch by
-        default.
+        The name of the distribution. Wildcards are permitted.
+    
+    .PARAMETER Distribution
+        Specifies WslDistribution objects that represent the distributions to be removed.
     
     .PARAMETER KeepDirectory
         If specified, keep the distribution directory. This allows recreating
         the distribution from a saved root file system.
 
     .INPUTS
-        None.
+        WslDistribution, System.String
+        
+        You can pipe a WslDistribution object retrieved by Get-Wsl, 
+        or a string that contains the distribution name to this cmdlet.
 
     .OUTPUTS
         None.
 
     .EXAMPLE
         Uninstall-Wsl toto
+
+        Uninstall distribution named toto.
     
+    .EXAMPLE
+        Uninstall-Wsl test*
+
+        Uninstall all distributions which names start by test.
+
+    .EXAMPLE
+        Get-Wsl -State Stopped | Sort-Object -Property -Size -Last 1 | Uninstall-Wsl
+
+        Uninstall the largest non running distribution.
+
     .LINK
         Install-Wsl
         https://github.com/romkatv/powerlevel10k
@@ -343,29 +597,33 @@ function Uninstall-Wsl {
         do an operation that already has been done before.
 
     #>    
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
-        [Parameter(Position = 0, Mandatory = $true)]
-        [string]$Name,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "DistributionName", Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [SupportsWildCards()]
+        [string[]]$Name,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "Distribution")]
+        [WslDistribution[]]$Distribution,
         [Parameter(Mandatory = $false)]
         [switch]$KeepDirectory
     )
 
-    # Retrieve the distribution if it already exists
-    $current_distribution = Get-ChildItem HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss |  Where-Object { $_.GetValue('DistributionName') -eq $Name }
-    if ($null -eq $current_distribution) {
-        throw [UnknownDistributionException] $Name
-    }
+    process {
+        if ($PSCmdlet.ParameterSetName -eq "DistributionName") {
+            $Distribution = Get-Wsl $Name
+        }
 
-    # Where to install the distribution
-    $distribution_dir = $current_distribution.GetValue('BasePath')
-
-    if ($PSCmdlet.ShouldProcess($Name, 'Unregister distribution')) {
-        Write-Verbose "Unregistering WSL distribution $Name"
-        &$wslPath --unregister $Name 2>&1 | Write-Verbose 
-    }
-    if ($false -eq $KeepDirectory) {
-        Remove-Item -Path $distribution_dir -Recurse
+        if ($null -ne $Distribution) {
+            $Distribution | ForEach-Object {
+                if ($PSCmdlet.ShouldProcess($_.Name, "Unregister")) {
+                    $_.Unregister() | Write-Verbose
+                    if ($false -eq $KeepDirectory) {
+                        $_.BasePath | Remove-Item -Recurse
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -433,37 +691,40 @@ function Export-Wsl {
     )
 
     # Retrieve the distribution if it already exists
-    $current_distribution = Get-ChildItem HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss |  Where-Object { $_.GetValue('DistributionName') -eq $Name }
-    if ($null -eq $current_distribution) {
-        throw [UnknownDistributionException] $Name
-    }
+    [WslDistribution]$Distribution = Get-Wsl $Name
 
-    if ($OutputFile.Length -eq 0) {
-        if ($OutputName.Length -eq 0) {
-            $OutputName = $Name
-        }
-        $OutputFile = "$Destination\$OutputName.rootfs.tar.gz"
-        If (!(test-path -PathType container $Destination)) {
-            if ($PSCmdlet.ShouldProcess($Destination, 'Create Wsl base directory')) {
-                $null = New-Item -ItemType Directory -Path $Destination
+    if ($null -ne $Distribution) {
+        $Distribution | ForEach-Object {
+
+
+            if ($OutputFile.Length -eq 0) {
+                if ($OutputName.Length -eq 0) {
+                    $OutputName = $Distribution.Name
+                }
+                $OutputFile = "$Destination\$OutputName.rootfs.tar.gz"
+                If (!(test-path -PathType container $Destination)) {
+                    if ($PSCmdlet.ShouldProcess($Destination, 'Create Wsl base directory')) {
+                        $null = New-Item -ItemType Directory -Path $Destination
+                    }
+                }
+            }
+
+            if ($PSCmdlet.ShouldProcess($Distribution.Name, 'Export distribution')) {
+
+
+                $export_file = $OutputFile -replace '\.gz$'
+
+                Write-Host "####> Exporting WSL distribution $Name to $export_file..."
+                Invoke-Wsl --export $Distribution.Name "$export_file" | Write-Verbose
+                $file_item = Get-Item -Path "$export_file"
+                $filepath = $file_item.Directory.FullName
+                Write-Host "####> Compressing $export_file to $OutputFile..."
+                Remove-Item "$OutputFile" -Force -ErrorAction SilentlyContinue
+                Invoke-Wsl -d $Name --cd "$filepath" gzip $file_item.Name | Write-Verbose
+
+                Write-Host "####> Distribution $Name saved to $OutputFile."
             }
         }
-    }
-
-    if ($PSCmdlet.ShouldProcess($Name, 'Export distribution')) {
-
-
-        $export_file = $OutputFile -replace '\.gz$'
-
-        Write-Host "####> Exporting WSL distribution $Name to $export_file..."
-        &$wslPath --export $Name "$export_file" | Write-Verbose
-        $file_item = Get-Item -Path "$export_file"
-        $filepath = $file_item.Directory.FullName
-        Write-Host "####> Compressing $export_file to $OutputFile..."
-        Remove-Item "$OutputFile" -Force -ErrorAction SilentlyContinue
-        &$wslPath -d $Name --cd "$filepath" gzip $file_item.Name | Write-Verbose
-
-        Write-Host "####> Distribution $Name saved to $OutputFile."
     }
 }
 
@@ -471,3 +732,4 @@ Export-ModuleMember Install-Wsl
 Export-ModuleMember Uninstall-Wsl
 Export-ModuleMember Export-Wsl
 Export-ModuleMember Get-WslRootFS
+Export-ModuleMember Get-Wsl


### PR DESCRIPTION
This PR introduces the `WslDistrbution` class and the `Get-Wsl` command. This command allows doing the following:


```powershell
>  Get-Wsl -State Running | sort-object -property size -descending | Format-Table -Property *

FileSystemPath BlockFile  Size Name    State Version Default Guid                                 BasePath
-------------- ---------  ---- ----    ----- ------- ------- ----                                 --------
\\wsl$\Arch    ext4.vhdx 33127 Arch  Running       2    True 10cfcf2f-d4e5-4c1f-a9c7-5d3dc7f9109f C:\Users\AntoineMartin\scoop\persist\archwsl\data
\\wsl$\godev   ext4.vhdx 32799 godev Running       2   False c21f4f5d-81c2-49fa-8776-7495a269d3f8 C:\Users\AntoineMartin\Documents\src\godev
```

Or

```powershell
>  (Get-Wsl -State Running).Stop()
```

It makes also changes to the documentation.
