### PR TITLE
⬆️ Update rootfses versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ on:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 env:
-  ARCHLINUX_RELEASE: "2023.01.01"
+  ARCHLINUX_RELEASE: "2023.12.01"
 
 jobs:
   build-archlinux-base:
@@ -47,11 +47,11 @@ jobs:
         flavor: [ubuntu, arch, alpine, debian, opensuse]
         include:
           - flavor: ubuntu
-            base_url: https://cloud-images.ubuntu.com/wsl/kinetic/current/ubuntu-kinetic-wsl-amd64-wsl.rootfs.tar.gz
+            base_url: https://cloud-images.ubuntu.com/wsl/mantic/current/ubuntu-mantic-wsl-amd64-wsl.rootfs.tar.gz
           - flavor: arch
             base_url: file://${GITHUB_WORKSPACE}/archlinuxbase-rootfs/archlinux.rootfs.tar.gz
           - flavor: alpine
-            base_url: https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.0-x86_64.tar.gz
+            base_url: https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-minirootfs-3.19.0-x86_64.tar.gz
           - flavor: debian
             base_url: https://doi-janky.infosiftr.net/job/tianon/job/debuerreotype/job/amd64/lastSuccessfulBuild/artifact/bullseye/rootfs.tar.xz
           - flavor: opensuse

--- a/Wsl-Manager.psm1
+++ b/Wsl-Manager.psm1
@@ -409,15 +409,17 @@ function Install-Wsl {
         &$wslPath --import $Name $distribution_dir $rootfs_file | Write-Verbose
     }
 
-    if ($false -eq $SkipConfigure -And !$rootfs.AlreadyConfigured) {
+    if ($false -eq $SkipConfigure) {
         if ($PSCmdlet.ShouldProcess($Name, 'Configure distribution')) {
-            Progress "Running initialization script [configure.sh] on distribution [$Name]..."
-            Push-Location "$module_directory"
-            &$wslPath -d $Name -u root ./configure.sh 2>&1 | Write-Verbose
-            Pop-Location
-            if ($LASTEXITCODE -ne 0) {
-                throw "Configuration failed"
-            }    
+            if (!$rootfs.AlreadyConfigured) {
+                Progress "Running initialization script [configure.sh] on distribution [$Name]..."
+                Push-Location "$module_directory"
+                &$wslPath -d $Name -u root ./configure.sh 2>&1 | Write-Verbose
+                Pop-Location
+                if ($LASTEXITCODE -ne 0) {
+                    throw "Configuration failed"
+                }        
+            }
             Get-ChildItem HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss |  Where-Object { $_.GetValue('DistributionName') -eq $Name } | Set-ItemProperty -Name DefaultUid -Value 1000
         }
     }


### PR DESCRIPTION
This pull request updates the versions of the rootfses used in the build process. The changes include:

- Updating the ARCHLINUX_RELEASE to "2023.12.01"

- Updating the base_url for Ubuntu flavor to "https://cloud-images.ubuntu.com/wsl/mantic/current/ubuntu-mantic-wsl-amd64-wsl.rootfs.tar.gz"

- Updating the base_url for Alpine flavor to "https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-minirootfs-3.19.0-x86_64.tar.gz"

- Make configuration check only if should process.

These changes ensure that the build process uses the latest versions of the rootfses.