### PR TITLE
Feature/get information from docker labels

### DIFF
--- a/Distributions.psd1
+++ b/Distributions.psd1
@@ -25,6 +25,8 @@
         }
         Release = 'current'
         Configured = $false
+        Username = 'root'
+        Uid = 0
     }
     Alpine   = @{
         Name    = 'Alpine'
@@ -36,6 +38,8 @@
         }
         Release = '3.22'
         Configured = $false
+        Username = 'root'
+        Uid = 0
     }
     Ubuntu   = @{
         Name    = 'Ubuntu'
@@ -47,6 +51,8 @@
         }
         Release = 'noble'
         Configured = $false
+        Username = 'root'
+        Uid = 0
     }
     Debian   = @{
         Name    = 'Debian'
@@ -61,6 +67,8 @@
         }
         Release = 'bookworm'
         Configured = $false
+        Username = 'root'
+        Uid = 0
     }
     OpenSuse = @{
         Name    = 'OpenSuse'
@@ -72,6 +80,8 @@
         }
         Release = 'tumbleweed'
         Configured = $false
+        Username = 'root'
+        Uid = 0
     }
 
     # Configured distributions (pre-configured/miniwsl)
@@ -83,6 +93,8 @@
         }
         Release = 'current'
         Configured = $true
+        Username = 'arch'
+        Uid = 1000
     }
     AlpineConfigured   = @{
         Name    = 'Alpine'
@@ -92,6 +104,8 @@
         }
         Release = '3.22'
         Configured = $true
+        Username = 'alpine'
+        Uid = 1000
     }
     UbuntuConfigured   = @{
         Name    = 'Ubuntu'
@@ -101,6 +115,8 @@
         }
         Release = 'noble'
         Configured = $true
+        Username = 'ubuntu'
+        Uid = 1000
     }
     DebianConfigured   = @{
         Name    = 'Debian'
@@ -110,6 +126,8 @@
         }
         Release = 'bookworm'
         Configured = $true
+        Username = 'debian'
+        Uid = 1000
     }
     OpenSuseConfigured = @{
         Name    = 'OpenSuse'
@@ -119,5 +137,7 @@
         }
         Release = 'tumbleweed'
         Configured = $true
+        Username = 'opensuse'
+        Uid = 1000
     }
 }

--- a/Wsl-Manager.psm1
+++ b/Wsl-Manager.psm1
@@ -435,8 +435,11 @@ function Install-Wsl {
                     throw "Configuration failed"
                 }
             }
-            Get-ChildItem HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss |  Where-Object { $_.GetValue('DistributionName') -eq $Name } | Set-ItemProperty -Name DefaultUid -Value 1000
         }
+    }
+
+    if ($rootfs.Uid -ne 0) {
+        Get-ChildItem HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss |  Where-Object { $_.GetValue('DistributionName') -eq $Name } | Set-ItemProperty -Name DefaultUid -Value $rootfs.Uid
     }
 
     Success "Done. Command to enter distribution: wsl -d $Name"

--- a/Wsl-RootFS.Tests.ps1
+++ b/Wsl-RootFS.Tests.ps1
@@ -40,10 +40,14 @@ Describe "WslRootFileSystem" {
             $rootFs.Configured | Should -BeFalse
             $rootFs.Type -eq [WslRootFileSystemType]::Builtin | Should -BeTrue
             $rootFs.Url | Should -Be $($script:Distributions['Alpine']['Url'])
+            $rootFs.Username | Should -Be "root"
+            $rootFs.Uid | Should -Be 0
 
             $rootFs = [WslRootFileSystem]::new("alpine", $true)
             $rootFs.Configured | Should -BeTrue
             $rootFs.Url | Should -Be $($script:Distributions['AlpineConfigured']['Url'])
+            $rootFs.Username | Should -Be "alpine"
+            $rootFs.Uid | Should -Be 1000
         }
 
         It "Should split properly external URL" {

--- a/docs/usage/install-distributions.md
+++ b/docs/usage/install-distributions.md
@@ -136,7 +136,7 @@ image.
 To install a Docker based distribution, you can use the following command:
 
 ```bash
-PS> install-wsl bw -Distribution docker:my-docker-image
+PS> install-wsl bw -Distribution docker://ghcr.io/antoinemartin/powershell-wsl-manager/arch-base#latest
 ⌛ Creating directory [C:\Users\AntoineMartin\AppData\Local\Wsl\bw]...
 ⌛ Getting docker authentication token for registry ghcr.io and repository antoinemartin/powershell-wsl-manager/arch-base...
 ⌛ Getting image manifests from https://ghcr.io/v2/antoinemartin/powershell-wsl-manager/arch-base/manifests/latest...
@@ -176,5 +176,7 @@ Currently Wsl-Manager only supports docker images that contain only one layer.
 [incus images]: https://images.linuxcontainers.org/images
 [incus image list]: https://images.linuxcontainers.org/images/
 [incus]: https://linuxcontainers.org/
-[json incus image list]: https://images.linuxcontainers.org/imagesstreams/v1/index.json
-[json incus images detail]: https://images.linuxcontainers.org/imagesstreams/v1/images.json
+[json incus image list]:
+  https://images.linuxcontainers.org/imagesstreams/v1/index.json
+[json incus images detail]:
+  https://images.linuxcontainers.org/imagesstreams/v1/images.json


### PR DESCRIPTION
This pull request introduces support for tracking and configuring default usernames and UIDs for each WSL distribution, improving consistency and flexibility when installing and managing distributions. The changes ensure that both built-in and configured distributions have explicit `Username` and `Uid` properties, and these are now properly handled throughout the codebase, including metadata serialization, deserialization, and installation logic.

**Enhancements to distribution user and UID handling:**

* Added `Username` and `Uid` properties to each distribution in `Distributions.psd1`, with root/0 for base images and distro/1000 for configured images. [[1]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR28-R29) [[2]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR41-R42) [[3]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR54-R55) [[4]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR70-R71) [[5]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR83-R84) [[6]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR96-R97) [[7]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR107-R108) [[8]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR118-R119) [[9]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR129-R130) [[10]](diffhunk://#diff-4e068b12bc168c84038ca095237669c3096c2d41cf80bca87f7ce2d15be44fcbR140-R141)
* Updated the `WslRootFileSystem` class to include `Username` and `Uid` fields, set these based on distribution configuration, and handle them when loading/saving metadata and parsing Docker/Incus images. [[1]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR623-R624) [[2]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR515-R516) [[3]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bL503-R538) Ffa3a60dL40R40, [[4]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR330-R345) [[5]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR362) [[6]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bL364-R393) [[7]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR1559-R1560)

**Improvements to installation and configuration logic:**

* Modified `Install-Wsl` to set the default UID based on the distribution's `Uid` property, instead of always using 1000.
* Enhanced the `init` method and Docker/Incus image parsing to set `Username` and `Uid` appropriately, including support for custom image labels. [[1]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR289-L295) [[2]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR330-R345) [[3]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bR362) [[4]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bL364-R393) [[5]](diffhunk://#diff-aecd5c9cd12bc8b21754d8bee5ec4166e4081936a9c8a57fd4a4103aa31b899bL307)

**Documentation updates:**

* Updated the Docker install example in the documentation for clarity and accuracy.
* Improved formatting of Incus image list links in the documentation.